### PR TITLE
Add logic to remember if the car is a Vectra

### DIFF
--- a/src/CAN.ino
+++ b/src/CAN.ino
@@ -127,7 +127,7 @@ void canReceiveTask(void *pvParameters){
 // this task processes filtered CAN frames read from canRxQueue
 void canProcessTask(void *pvParameters){
   static twai_message_t RxMsg;
-  bool badVoltage_VectraC_bypass=0;
+  bool badVoltage_VectraC_bypass=getPreferencesBool("vectra"); // read from the preferences to check if the car is a vectra
   unsigned long millis_EccKnobPressed;
   while(1){
     xQueueReceive(canRxQueue, &RxMsg, portMAX_DELAY);     // receives data from the internal queue
@@ -267,6 +267,7 @@ void canProcessTask(void *pvParameters){
                   snprintf(voltage_buffer, sizeof(voltage_buffer), "Voltage: %.1f V  ", CAN_data_voltage);
                 } else {            // we get erroneous readings, as such we'll switch to reading from display on the next measurement request
                   badVoltage_VectraC_bypass=1;
+                  setPreferencesBool("vectra", 1);
                 }
                 setFlag(CAN_voltage_recvd);
                 DEBUG_PRINT("battery voltage\n");

--- a/src/EHU32.ino
+++ b/src/EHU32.ino
@@ -110,6 +110,7 @@ void setup(){
     settings.putBool("setupcomplete", 0);
     settings.putBool("uhppresent", 0);
     settings.putBool("eccpresent", 0);
+    settings.putBool("vectra", 0);
     settings.putUInt("identifier", 0);
   }
   bool init_setupComplete=settings.getBool("setupcomplete", 0);   // prefs init
@@ -219,6 +220,24 @@ void canWatchdogTask(void *pvParameters){
     }
     vTaskDelay(pdMS_TO_TICKS(1000));
   }
+}
+
+// reads settings from preferences
+bool getPreferencesBool(const char* key){
+  Preferences settings;
+  bool result;
+  settings.begin("my-app", true);
+  result=settings.getBool(key, 0);
+  settings.end();
+  return result;
+}
+
+// writes settings to preferences
+void setPreferencesBool(const char* key, bool value){
+  Preferences settings;
+  settings.begin("my-app", false);
+  settings.putBool(key, value);
+  settings.end();
 }
 
 // below functions are used to simplify interaction with freeRTOS eventGroups


### PR DESCRIPTION
It's been slightly annoying to wait until the "voltage" reading from the Vectra/Signum ECC drops below 9V or above 16V and the EHU32 starts pulling the reading from the DIS. This adds an extra bool in the preferences so the EHU32 remembers it's in a Vectra. There's probably a more elegant way around this though.